### PR TITLE
Add iterative upscale node

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ This node merges all tiled conditions into one and prepares them for building th
 
 ---
 
+### **7. Iterative Upscale Node**
+This node crops and upscales an image multiple times. Use it together with **TTP_Expand_And_Mask** to create an infinite zoom effect.
+
+| Parameter | Description |
+|-----------|-------------|
+| **Iterations** | Number of upscale cycles. |
+| **Scale Factor** | Factor used for each upscale step. |
+| **Crop X/Y/Width/Height** | Optional region to crop before scaling. |
+
+**Example Chain**: `TTP_Expand_And_Mask → TTP_Iterative_Upscale` (repeat as needed)
+
+---
+
 ## **Examples**
 
 ### **Pixel Example (Recommended)**


### PR DESCRIPTION
## Summary
- implement `TTP_Iterative_Upscale` node for multi-step crop and resize
- register the node in mappings
- document Iterative Upscale node in README with example chain

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e77cf0f288320b0ab6e5a68ab2cfb